### PR TITLE
fixes #21: Force xmpp-addr version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
         </dependency>
 
         <dependency>
+            <groupId>rocks.xmpp</groupId>
+            <artifactId>xmpp-addr</artifactId>
+            <version>0.8.0</version>
+        </dependency>
+             
+        <dependency>
             <groupId>com.github.inputmice</groupId>
             <artifactId>xmpp-addr-adapter</artifactId>
             <version>0.1</version>


### PR DESCRIPTION
By making `xmpp-addr` a first-order dependency of the project, Maven's version resolution mechanism should use the version defined in this pom.